### PR TITLE
Make rewrite pattern non greedy

### DIFF
--- a/classes/Dispatcher.php
+++ b/classes/Dispatcher.php
@@ -37,7 +37,7 @@ class DispatcherCore
     const FC_ADMIN = 2;
     const FC_MODULE = 3;
 
-    const REWRITE_PATTERN = '[_a-zA-Z0-9\x{0600}-\x{06FF}\pL\pS-]*';
+    const REWRITE_PATTERN = '[_a-zA-Z0-9\x{0600}-\x{06FF}\pL\pS-]*?';
 
     /**
      * @var Dispatcher


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Correct the default rewrite pattern to make it non greedy, so that others ids will be parsed wherever they are located in the route. A bug prevents to directly access with its direct URL a product combination that is not the default one.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | N/A
| How to test?  | In the BO, in the SEO & URL page, in the field Product route enter "{manufacturer:/}{rewrite}{-:id_product_attribute}-{id}". Then in the FO go to the page of a product with a combination. With this patch, the id_product_attribute will be taken into account and the right combination shown, without you will go to the default combination, and if you debug you'll see that id_product_attribute was not retrieved.<br/><br/>You can also test with "{manufacturer:/}{rewrite}-{id}{-:id_product_attribute}", without the patch Prestashop will be confused and take the product_attribute_id as the product_id.